### PR TITLE
Step 5 to 8

### DIFF
--- a/general.yaml
+++ b/general.yaml
@@ -2,7 +2,7 @@
 - name: Add SSH keys for Vagrant user
   hosts: all
   gather_facts: false
-
+  become: true
   vars:
     ssh_key_dir: "{{ playbook_dir }}/ssh-keys"
     ssh_key_files: "{{ lookup('fileglob', ssh_key_dir + '/*.pub', wantlist=True) }}"
@@ -20,3 +20,55 @@
         state: present
         key: "{{ lookup('file', item) }}"
       loop: "{{ ssh_key_files }}"
+
+    - name: Disable swap immediately
+      ansible.builtin.shell: swapoff -a
+
+    - name: Remove swap from fstab to prevent remount on boot
+      ansible.builtin.lineinfile:
+        path: /etc/fstab
+        regexp: '^\s*[^#].*\sswap\s'
+        state: absent
+
+    - name: Ensure overlay and br_netfilter modules are loaded on boot
+      ansible.builtin.copy:
+        dest: /etc/modules-load.d/k8s.conf
+        content: |
+          overlay
+          br_netfilter
+        owner: root
+        group: root
+        mode: '0644'
+
+    - name: Load br_netfilter module now
+      ansible.builtin.modprobe:
+        name: br_netfilter
+        state: present
+
+    - name: Load overlay module now
+      ansible.builtin.modprobe:
+        name: overlay
+        state: present
+
+    - name: Configure sysctl params for Kubernetes networking
+      ansible.builtin.copy:
+        dest: /etc/sysctl.d/k8s.conf
+        content: |
+          net.bridge.bridge-nf-call-iptables = 1
+          net.bridge.bridge-nf-call-ip6tables = 1
+          net.ipv4.ip_forward = 1
+        owner: root
+        group: root
+        mode: '0644'
+
+    - name: Apply sysctl parameters
+      ansible.builtin.command: sysctl --system
+
+    - name: Deploy /etc/hosts using template
+      ansible.builtin.template:
+        src: "{{ playbook_dir }}/templates/hosts.j2"
+        dest: /etc/hosts
+        owner: root
+        group: root
+        mode: '0644'
+

--- a/templates/hosts.j2
+++ b/templates/hosts.j2
@@ -1,0 +1,9 @@
+127.0.0.1   localhost
+
+# Controller
+192.168.56.100   ctrl
+
+# Workers
+{% for i in range(1, worker_count + 1) %}
+192.168.56.{{ 100 + i }}   node-{{ i }}
+{% endfor %}

--- a/vagrantfile
+++ b/vagrantfile
@@ -39,6 +39,9 @@ Vagrant.configure("2") do |config|
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "general.yaml"
     ansible.limit = "all"
+    ansible.extra_vars = {
+    worker_count: WORKER_COUNT
+  }
   end
 
   config.vm.provision "ansible", run: "always" do |ansible|


### PR DESCRIPTION
Disable swap, load required kernel modules, enable IPv4 and bridge forwarding, and configure /etc/hosts for all cluster nodes. Ensures all nodes can communicate by hostname and are ready for Kubernetes installation.
