### PR TITLE
fix: warnings of helm install

### DIFF
--- a/ACTIVITY.md
+++ b/ACTIVITY.md
@@ -86,3 +86,8 @@
 - Jimmy: https://github.com/doda25-team15/operation/pull/72
 
   Worked on start of Grafana dashboards.
+
+### Week 5 (Dec 8-14)
+
+- Arjun: https://github.com/doda25-team15/operation/pull/87
+ Worked on resolving the warnings which show up when installing helm 

--- a/helm_chart/values.yaml
+++ b/helm_chart/values.yaml
@@ -61,6 +61,23 @@ monitoring:
       serviceMonitorSelector:
         matchLabels:
           team: doda25-team15
+    service:
+      sessionAffinity: ""
+
+  alertmanager:
+    service:
+      sessionAffinity: ""
+
+  coreDns:
+    enabled: false
+  kubeEtcd:
+    enabled: false
+  kubeControllerManager:
+    enabled: false
+  kubeScheduler:
+    enabled: false
+  kubeProxy:
+    enabled: false
 
   grafana:
     enabled: true


### PR DESCRIPTION
Resolved spec.SessionAffinity is ignored warnings: Identified that the kube-prometheus-stack dependency was creating headless services for Kubernetes control plane components, which triggered validation warnings.
Disabled unused Control Plane Exporters: Updated values.yaml
 to disable coreDns, kubeEtcd, kubeControllerManager, kubeScheduler, and kubeProxy. These exporters create the problematic headless services and are generally not required for local Minikube development.
Explicitly unset Session Affinity: Added configuration to explicitly set sessionAffinity: "" for alertmanager and prometheus services to ensure clean service definitions and prevent default values from triggering additional warnings.