### PR TITLE
stickiness updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,28 @@ Open in browser
 http://localhost:8080/sms/
 ```
 
+### Test stickiness
+
+Creates new session (new cookie) and displays it in the terminal:
+
+```bash
+curl -H "Host: sms-checker-app" -v http://<external ip>:80
+```
+
+It is possible to save this cookie and store in a txt file to use it:
+```bash
+curl -c cookies.txt -b cookies.txt -H "Host: sms-checker-app" -v http://<external ip>:80
+```
+txt is automatically generated and the cookie is placed there.
+
+Can also send cookie without creating new files, but you will have to copy the cookie:
+
+```bash
+curl -H "Host: sms-checker-app" \
+     -H 'Cookie: user-session="<cookie>"' \
+     -v http://<external ip>
+```
+
 ### Additional Istio Use Case: Shadow Launch
 
 #### Prerequisite

--- a/helm_chart/templates/destination-rule-app.yaml
+++ b/helm_chart/templates/destination-rule-app.yaml
@@ -10,10 +10,13 @@ spec:
   host: {{ .Values.service.app.name }}
   trafficPolicy:
     loadBalancer:
+      {{- if .Values.trafficManagement.stickySessions.enabled }}
       consistentHash:
         httpCookie:
-          name: user-session
-          ttl: 3600s
+          name: {{ .Values.trafficManagement.stickySessions.cookieName }}
+          ttl: {{ .Values.trafficManagement.stickySessions.ttl }}
+      {{- end }}
+
     connectionPool:
       http:
         http1MaxPendingRequests: 1024

--- a/helm_chart/values.yaml
+++ b/helm_chart/values.yaml
@@ -98,6 +98,10 @@ trafficManagement:
   weights:
     stable: 90
     canary: 10
+  stickySessions:
+    enabled: true
+    cookieName: user-session
+    ttl: 3600s
 
 shadow:
   enabled: true


### PR DESCRIPTION
stickiness variables in decision rule can be disabled thought values.yaml. Added readme section about stickiness and cookies. To further demonstrate that stickiness is working, we could display the pod name and version in the application, but this would require updating the application and pushing a new image. Closes #93 