### PR TITLE
Only copy model files in node hosts

### DIFF
--- a/ansible/general.yaml
+++ b/ansible/general.yaml
@@ -171,26 +171,3 @@
         name: kubelet
         state: started
         enabled: yes
-
-    - name: Create shared model directory
-      file:
-        path: /mnt/shared/output
-        state: directory
-        mode: '0755'
-
-    - name: Copy model.joblib to nodes
-      copy:
-        src: "{{ playbook_dir }}/../model/model.joblib"
-        dest: /mnt/shared/output/model.joblib
-        mode: '0644'
-
-    - name: Copy preprocessor.joblib to nodes
-      copy:
-        src: "{{ playbook_dir }}/../model/preprocessor.joblib"
-        dest: /mnt/shared/output/preprocessor.joblib
-        mode: '0644'
-
-    - name: Verify model files exist
-      command: ls -lh /mnt/shared/output/
-      register: ls_output
-      changed_when: false

--- a/ansible/node.yaml
+++ b/ansible/node.yaml
@@ -2,6 +2,29 @@
 - hosts: "node-*"
   become: yes
   tasks:
+    - name: Create shared model directory
+      file:
+        path: /mnt/shared/output
+        state: directory
+        mode: '0755'
+
+    - name: Copy model.joblib to nodes
+      copy:
+        src: "{{ playbook_dir }}/../model/model.joblib"
+        dest: /mnt/shared/output/model.joblib
+        mode: '0644'
+
+    - name: Copy preprocessor.joblib to nodes
+      copy:
+        src: "{{ playbook_dir }}/../model/preprocessor.joblib"
+        dest: /mnt/shared/output/preprocessor.joblib
+        mode: '0644'
+
+    - name: Verify model files exist
+      command: ls -lh /mnt/shared/output/
+      register: ls_output
+      changed_when: false
+
     # STEP 18 — Generate Join Command
     - name: Generate kubeadm join command on controller
       shell: kubeadm token create --print-join-command


### PR DESCRIPTION
As only the worker nodes actually need the model files, it makes sense to only provide the files there. This PR removes the copying of the model files from `general.yaml`, and moves it to `node.yaml` so that only the worker nodes will have them.